### PR TITLE
add a way to run imagestream transfers concurrently

### DIFF
--- a/1_imagestream_data_gen/imagestream_data_gen.py
+++ b/1_imagestream_data_gen/imagestream_data_gen.py
@@ -119,6 +119,8 @@ for item in namespaces:
                     # source_registry_in_image_tag = source_registry_url == image_reference_split[0]
                     # destination_image_tag = destination_image_tag.lstrip(source_registry_url + "/")
                     tags_to_migrate.append({
+                        "imagestream_name": imagestream.metadata.name,
+                        "imagestream_namespace": imagestream.metadata.namespace,
                         "docker_image_reference": docker_image_reference,
                         "imagestream_tag": imagestream_tag,
                         "image_name": image_name,

--- a/2_imagestream_copy/imagestream-copy.yml
+++ b/2_imagestream_copy/imagestream-copy.yml
@@ -66,15 +66,30 @@
         definition: "{{ lookup('template', 'namespace.yml.j2') }}"
       loop: "{{ namespace_data }}"
 
+    - set_fact:
+        input_length: "{{ image_data|length }}"
+        batched_list: []
+        batch_size: "{{ concurrent_is_transfers }}"
+
+    - name: "Generate list of batches"
+      set_fact:
+        batched_list: "{{ batched_list + [image_data[split0|int:split1|int]] }}"
+      vars:
+        split0: "{{ ansible_loop.previtem|default(0) }}"
+        split1: "{{ ansible_loop.last|ternary(input_length, item) }}"
+      loop: "{{ range(batch_size, input_length|int + batch_size, batch_size)|list }}"
+      loop_control:
+        extended: yes
+
     - name: "Set fact for collecting output"
       set_fact:
         failures: []
 
     - name: "Copy the images"
-      vars:
-        tags_to_migrate: "{{ item.tags | reverse | list }}"
-      include_tasks: "tasks/iterate-over-tags.yml"
-      loop: "{{ image_data }}"
+      include_tasks: tasks/run-batches.yml
+      loop: "{{ batched_list }}"
+
+    - debug: msg="{{ failures }}"
 
     - name: "Dumping failure report"
       copy:

--- a/2_imagestream_copy/tasks/collect-async-failures.yml
+++ b/2_imagestream_copy/tasks/collect-async-failures.yml
@@ -1,0 +1,17 @@
+- name: "check status of async job"
+  when: async_result_item is defined and async_result_item.ansible_job_id is defined
+  ignore_errors: yes
+  async_status:
+    jid: "{{ async_result_item.ansible_job_id }}"
+  register: async_poll_result
+
+- name: "check and add to failures"
+  when: async_poll_result.rc is defined and async_poll_result.rc != 0
+  vars:
+    failure:
+      - rc: "{{ async_poll_result.rc }}"
+        stderr: "{{ async_poll_result.stderr }}"
+        stdout: "{{ async_poll_result.stdout }}"
+        tag: "{{ async_result_item.tag_item }}"
+  set_fact:
+    failures: "{{ failures + failure }}"

--- a/2_imagestream_copy/tasks/iterate-over-tags.yml
+++ b/2_imagestream_copy/tasks/iterate-over-tags.yml
@@ -1,22 +1,28 @@
-# vars this task expects
+- name: "Start async sckopeo task and register job id"
+  when: tag_item != None
+  shell: "skopeo copy --src-creds {{ source_registry.username }}:{{ source_registry.password }} --dest-creds {{ destination_registry.username }}:{{ destination_registry.password }} --src-tls-verify=false --dest-tls-verify=false docker://{{ source_registry.url }}/{{ tag_item.source_image }} docker://{{ destination_registry.url }}/{{ tag_item.destination_image }}"
+  async: 1000
+  poll: 0
+  loop: "{{ item }}"
+  loop_control:
+    loop_var: "tag_item"
+  register: skopeo_output
 
-- name: "Set fact for failed tags"
-  set_fact:
-    failed_tags: []
-    report_failure:
-    - imagestream_name: "{{ item.imagestream_name }}"
-      imagestream_namespacee: "{{ item.imagestream_namespace }}"
-      tags: []
+- name: "Check status of skopeo"
+  when: async_result_item is defined and async_result_item.ansible_job_id is defined
+  ignore_errors: yes
+  async_status:
+    jid: "{{ async_result_item.ansible_job_id }}"
+  loop: "{{ skopeo_output.results }}"
+  loop_control:
+    loop_var: "async_result_item"
+  register: async_poll_results
+  until: async_poll_results.finished
+  retries: 30
+  delay: 5
 
-- name: "Migrate image tags"
-  include_tasks: "tasks/run-skopeo.yml"
-  loop: "{{ tags_to_migrate }}"
-
-- name: "Report failed tags"
-  set_fact:
-    report_failure: "{{ report_failure[0].tags + failed_tags }}"
-
-- name: "Append to failed output"
-  set_fact:
-    failures: "{{ failures + report_failure }}"
-  when: failed_tags|length > 0
+- name: "Collect failed results"
+  include_tasks: tasks/collect-async-failures.yml
+  loop: "{{ skopeo_output.results }}"
+  loop_control:
+    loop_var: "async_result_item"

--- a/2_imagestream_copy/tasks/run-batches.yml
+++ b/2_imagestream_copy/tasks/run-batches.yml
@@ -1,0 +1,15 @@
+- set_fact:
+    tags_to_migrate: []
+
+- name: "get the list of tags"
+  set_fact:
+    tags_to_migrate: "{{ tags_to_migrate + [item.tags | reverse | list] }}"
+  loop: "{{ item }}"
+
+- debug: msg="{{ item }}"
+  with_together: "{{ tags_to_migrate }}"
+
+- name: "Start batched ImageStream transfer"
+  include_tasks: tasks/iterate-over-tags.yml
+  with_together: "{{ tags_to_migrate }}"
+

--- a/2_imagestream_copy/vars/imagestream-copy.yml.example
+++ b/2_imagestream_copy/vars/imagestream-copy.yml.example
@@ -11,3 +11,4 @@ destination_registry:
 image_data_filepath: ../output/image-data.json
 namespace_data_filepath: ../output/namespace-data.json
 output_dir: ../output
+concurrent_is_transfers: 3


### PR DESCRIPTION
This introduces a new variable `concurrent_is_transfers` which
defines the number of imagestream transfers that can happen
concurrently. If the imagestream has multiple tags, they are still
being transferred serially to preserve the order of creation at
destination